### PR TITLE
Support top level itemless modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Form
 ![crates.io badge](https://img.shields.io/crates/v/form.svg)
-[![CircleCI](https://circleci.com/gh/djmcgill/form/tree/master.svg?style=svg)](https://circleci.com/gh/djmcgill/form/tree/master)
+[![CircleCI](https://circleci.com/gh/djmcgill/form/tree/main.svg?style=svg)](https://circleci.com/gh/djmcgill/form/tree/main)
 
 A library for splitting apart a large file with multiple modules into the idiomatic rust directory structure, intended for use with svd2rust.
 Creates a lib.rs as well as a subdirectory structure in the target directory. It does NOT create the cargo project or the cargo manifest file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,5 +39,5 @@ fn run() -> Result<(), Error> {
         create_directory_structure(opts.output_dir, opts.input)?;
         println!("Completed successfully");
     }
-    return Ok(());
+    Ok(())
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -13,10 +13,10 @@ pub struct FormOpts {
 
 impl FormOpts {
     pub fn from_args() -> Result<Option<Self>, Error> {
-        const SHORT_INPUT: &'static str = "i";
-        const SHORT_OUTDIR: &'static str = "o";
-        const SHORT_HELP: &'static str = "h";
-        const SHORT_VERSION: &'static str = "v";
+        const SHORT_INPUT: &str = "i";
+        const SHORT_OUTDIR: &str = "o";
+        const SHORT_HELP: &str = "h";
+        const SHORT_VERSION: &str = "v";
 
         let args: Vec<String> = env::args().collect();
         let program = args[0].clone();
@@ -42,7 +42,7 @@ impl FormOpts {
         }
         let output_dir = matches
             .opt_str(SHORT_OUTDIR)
-            .ok_or(err_msg("Output directory missing"))?;
+            .ok_or_else(|| err_msg("Output directory missing"))?;
         let input = read_input(matches.opt_str(SHORT_INPUT))?;
 
         Ok(Some(FormOpts { output_dir, input }))

--- a/tests/resources/after/lib.rs
+++ b/tests/resources/after/lib.rs
@@ -13,3 +13,5 @@ pub mod interrupt;
 pub use cortex_m::peripheral::TPIU;
 pub struct AC;
 pub mod ac;
+
+mod foo;

--- a/tests/resources/small-lib-before.rs
+++ b/tests/resources/small-lib-before.rs
@@ -23,3 +23,5 @@ pub mod ac {
     }
     pub const AC: AC = AC;
 }
+
+mod foo;


### PR DESCRIPTION
Now if there is a `mod foo;` at the top level, instead of panicking it ignores it. If there's nested ones it goes back to panicking (since ignoring them produces broken code (the referenced file needs to be moved into the directory tree)) but at least has an actual error message now.
Closes https://github.com/djmcgill/form/issues/13