### PR TITLE
[Fixes #17] Stop consuming the content

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn run() -> Result<(), Error> {
         FormOpts::from_args().context("could not parse the command line arguments")?;
     // if None, we've already printed a help text or version and have nothing more to do
     if let Some(opts) = try_parsed_args {
-        create_directory_structure(opts.output_dir, opts.input)?;
+        create_directory_structure(opts.output_dir, &opts.input)?;
         println!("Completed successfully");
     }
     Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ use failure::*;
 
 pub fn create_directory_structure<P: AsRef<Path>>(
     base_dir: P,
-    string_contents: String,
+    string_contents: &str,
 ) -> Result<(), Error> {
     info!("Started parsing the input as Rust. This can take a minute or two.");
     let parsed_crate = syn::parse_file(&string_contents)

--- a/tests/file-test.rs
+++ b/tests/file-test.rs
@@ -18,7 +18,7 @@ fn test_from_reference_files() {
     let expected_ac3 = include_bytes!("resources/after/ac/ac2/ac3.rs");
 
     let lib_dir = tempdir().unwrap();
-    create_directory_structure(lib_dir.path(), before_file.to_string()).unwrap();
+    create_directory_structure(lib_dir.path(), before_file).unwrap();
 
     compare_to_expected(expected_lib, lib_dir.path().join("lib.rs"));
     compare_to_expected(expected_interrupt, lib_dir.path().join("interrupt.rs"));


### PR DESCRIPTION
The library function `create_directory_structure()` works well for `syn`. Addresses #17 and helps achieving atsams-rs/atsamx7x-rust#23.

Thanks in advance for quick care and release.